### PR TITLE
Fetch profile response fixes:  body and code response

### DIFF
--- a/app/services/github/profile_consumer.rb
+++ b/app/services/github/profile_consumer.rb
@@ -1,5 +1,7 @@
 module Github
   class ProfileConsumer
+    attr_reader :body, :code
+
     FIELDS_MAPPING = {
       nickname: 'login',
       avatar: 'avatar_url',
@@ -26,6 +28,7 @@ module Github
       github_response = ApiClient.new(username)
       github_response.fetch_profile_data
       self.github_profile = github_response.body
+      self.code = github_response.code
 
       return unless github_response.code == 200
 
@@ -34,6 +37,7 @@ module Github
 
     private
 
+    attr_writer :body, :code
     attr_accessor :github_profile, :username
 
     def build_response
@@ -41,7 +45,8 @@ module Github
       FIELDS_MAPPING.each do |profile_field, gh_field|
         assambled_profile[profile_field] = github_profile[gh_field]
       end
-      assambled_profile
+
+      self.body = assambled_profile
     end
   end
 end

--- a/app/services/github/profile_consumer.rb
+++ b/app/services/github/profile_consumer.rb
@@ -41,12 +41,12 @@ module Github
     attr_accessor :github_profile, :username
 
     def build_response
-      assambled_profile = {}
+      assembled_profile = {}
       FIELDS_MAPPING.each do |profile_field, gh_field|
-        assambled_profile[profile_field] = github_profile[gh_field]
+        assembled_profile[profile_field] = github_profile[gh_field]
       end
 
-      self.body = assambled_profile
+      self.body = assembled_profile
     end
   end
 end

--- a/spec/services/github/profile_consumer_spec.rb
+++ b/spec/services/github/profile_consumer_spec.rb
@@ -52,17 +52,23 @@ RSpec.describe Github::ProfileConsumer do
     end
 
     it 'returns right body class' do
-      expect(profile_consumer.call.class).to eq(Hash)
+      profile_consumer.call
+      expect(profile_consumer.body.class).to eq(Hash)
+    end
+
+    it 'returns right code' do
+      profile_consumer.call
+      expect(profile_consumer.code).to eq(200)
     end
 
     it 'returns right body content' do
-      expect(profile_consumer.call).to eq(expected_response)
+      profile_consumer.call
+      expect(profile_consumer.body).to eq(expected_response)
     end
   end
 
   describe 'when ApiClient code: 4XX' do
     let(:expected_response) { nil }
-    let(:result) { profile_consumer.call }
 
     before do
       profile_response = instance_double(
@@ -75,11 +81,18 @@ RSpec.describe Github::ProfileConsumer do
     end
 
     it 'returns right body class' do
-      expect(result.class).to eq(NilClass)
+      profile_consumer.call
+      expect(profile_consumer.body.class).to eq(NilClass)
+    end
+
+    it 'returns right code' do
+      profile_consumer.call
+      expect(profile_consumer.code).to eq(403)
     end
 
     it 'returns right body content' do
-      expect(result).to be_nil
+      profile_consumer.call
+      expect(profile_consumer.body).to be_nil
     end
   end
 end


### PR DESCRIPTION
This PR allows FetchProfile to respond with a code and a body to the controller, allowing Controller to build a response with a message,  at [PR#32](https://github.com/ImMPrada/github-profile-viewer-api/pull/32)