### PR TITLE
Fetch profile response fixes: destroy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,3 +22,6 @@ RSpec/MultipleMemoizedHelpers:
 
 Metrics/MethodLength:
   Max: 18
+
+RSpec/NestedGroups:
+  Max: 5

--- a/app/services/github/profile_consumer.rb
+++ b/app/services/github/profile_consumer.rb
@@ -41,12 +41,12 @@ module Github
     attr_accessor :github_profile, :username
 
     def build_response
-      assambled_profile = {}
+      assembled_profile = {}
       FIELDS_MAPPING.each do |profile_field, gh_field|
-        assambled_profile[profile_field] = github_profile[gh_field]
+        assembled_profile[profile_field] = github_profile[gh_field]
       end
 
-      self.body = assambled_profile
+      self.body = assembled_profile
     end
   end
 end

--- a/app/services/sync/fetch_profile.rb
+++ b/app/services/sync/fetch_profile.rb
@@ -10,6 +10,7 @@ module Sync
       self.profile = Profile.find_by(nickname: profile_name)
       call_for_github_data
       return if profile.blank? && github_profile.blank?
+      return if delete_profile
 
       create_profile_if_not_exists
       synchronize_profile
@@ -27,6 +28,13 @@ module Sync
       profile_consumer.call
       self.github_profile = profile_consumer.body
       self.code = profile_consumer.code
+    end
+
+    def delete_profile
+      return if profile.blank? || code != 404
+
+      Sync::SyncProfile.new(github_profile).delete_profile(profile)
+      true
     end
 
     def create_profile_if_not_exists

--- a/app/services/sync/sync_profile.rb
+++ b/app/services/sync/sync_profile.rb
@@ -18,6 +18,11 @@ module Sync
       profile
     end
 
+    def delete_profile(current_profile)
+      current_profile.destroy
+      self.profile = nil
+    end
+
     private
 
     attr_accessor :profile_data, :profile

--- a/spec/services/sync/fetch_profile_spec.rb
+++ b/spec/services/sync/fetch_profile_spec.rb
@@ -23,47 +23,70 @@ RSpec.describe Sync::FetchProfile do
       twitter: 'im_mprada'
     }
   end
-  let(:call_fetch_profile) { fetch_profile.call }
 
   describe '#call' do
-    describe 'profile from Github: doesn\'t exist, profile from DB: doesn\'t exist' do
-      before do
-        profile_call_fetch_profile = instance_double(
-          Github::ProfileConsumer,
-          call: {},
-          code: 404,
-          body: nil
-        )
-        allow(Github::ProfileConsumer).to receive(:new).and_return(profile_call_fetch_profile)
+    before do
+      profile_call_fetch_profile = instance_double(
+        Github::ProfileConsumer,
+        call: {},
+        code: github_response_code,
+        body: github_response_body
+      )
+      allow(Github::ProfileConsumer).to receive(:new).and_return(profile_call_fetch_profile)
+    end
 
-        profile = Profile.find_by(nickname: profile_name)
-        profile.destroy if profile.present?
+    describe "when the profile doesn't exist in github" do
+      let(:github_response_code) { 404 }
+      let(:github_response_body) { nil }
+
+      describe "when profile at DB doesn't exist" do
+        it 'returns nil' do
+          expect(fetch_profile.call).to be_nil
+        end
+
+        it 'returns nil body' do
+          fetch_profile.call
+          expect(fetch_profile.profile).to be_nil
+        end
+
+        it 'returns the right code' do
+          fetch_profile.call
+          expect(fetch_profile.github_code).to eq(404)
+        end
       end
 
-      it 'returns nil' do
-        expect(call_fetch_profile).to be_nil
-      end
+      describe 'when profile at DB exists' do
+        before do
+          location = create(:location)
+          create(:profile, nickname: profile_name, location: location)
+        end
 
-      it 'returns nil body' do
-        expect(fetch_profile.body).to be_nil
-      end
+        it 'destroys the profile' do
+          fetch_profile.call
+          expect(Profile.find_by(nickname: profile_name)).to be_nil
+        end
 
-      it 'returns the right code' do
-        call_fetch_profile
-        obtained_code = fetch_profile.code
-        expect(obtained_code).to eq(404)
+        it 'returns nil' do
+          expect(fetch_profile.call).to be_nil
+        end
+
+        it 'returns nil body' do
+          fetch_profile.call
+          expect(fetch_profile.profile).to be_nil
+        end
+
+        it 'returns the right code' do
+          fetch_profile.call
+          expect(fetch_profile.github_code).to eq(404)
+        end
       end
     end
 
-    describe 'profile from Github: exists, profile from DB: doesn\'t exist' do
+    describe 'when the profile exists in github' do
+      let(:github_response_code) { 200 }
+      let(:github_response_body) { profile_data }
+
       before do
-        profile_call_fetch_profile = instance_double(
-          Github::ProfileConsumer,
-          call: {},
-          code: 200,
-          body: profile_data
-        )
-        allow(Github::ProfileConsumer).to receive(:new).and_return(profile_call_fetch_profile)
         null_repo_consumer_call_fetch_profile = instance_double(
           Sync::FetchRepos,
           call: nil
@@ -71,102 +94,53 @@ RSpec.describe Sync::FetchProfile do
         allow(Sync::FetchRepos).to receive(:new).and_return(null_repo_consumer_call_fetch_profile)
       end
 
-      it 'saves profile data in DB' do
-        call_fetch_profile
-        expect(Profile.find_by(nickname: profile_name)).not_to be_nil
+      describe "when profile from DB: doesn't exist" do
+        it 'saves profile data in DB' do
+          fetch_profile.call
+          expect(Profile.find_by(nickname: profile_name)).not_to be_nil
+        end
+
+        it 'returns the right code' do
+          fetch_profile.call
+          expect(fetch_profile.github_code).to eq(200)
+        end
+
+        it 'returns the right profile from DB' do
+          fetch_profile.call
+          expect(fetch_profile.profile.url).to eq(profile_url)
+        end
       end
 
-      it 'returns the right code' do
-        call_fetch_profile
-        obtained_code = fetch_profile.code
-        expect(obtained_code).to eq(200)
-      end
+      describe 'when profile from DB exists, and needs to be updated' do
+        before do
+          location = create(:location)
+          create(:profile, nickname: profile_name, location: location)
+        end
 
-      it 'returns the right profile from DB' do
-        call_fetch_profile
-        expect(fetch_profile.body.url).to eq(profile_url)
-      end
-    end
+        it 'updates the profile in the DB' do
+          fetch_profile.call
+          from_db = Profile.find_by(nickname: profile_name)
+          obtained = from_db.values_at(:followers_count, :public_gists_count, :public_repos_count)
+          expected = profile_data.values_at(:followers_count, :public_gists_count, :public_repos_count)
 
-    describe 'profile from Github: exists, profile from DB: exists, and needs to be updated' do
-      let(:existing_profile) { create(:profile, git_date: '2022-07-01T00:16:27Z') }
+          expect(obtained).to eq(expected)
+        end
 
-      before do
-        profile_call_fetch_profile = instance_double(
-          Github::ProfileConsumer,
-          call: {},
-          code: 200,
-          body: profile_data
-        )
-        allow(Github::ProfileConsumer).to receive(:new).and_return(profile_call_fetch_profile)
+        it 'returns the right code' do
+          fetch_profile.call
+          expect(fetch_profile.github_code).to eq(200)
+        end
 
-        null_repo_consumer_call_fetch_profile = instance_double(
-          Sync::FetchRepos,
-          call: nil
-        )
-        allow(Sync::FetchRepos).to receive(:new).and_return(null_repo_consumer_call_fetch_profile)
-      end
+        it 'returns the profile updated, in the body' do
+          fetch_profile.call
+          obtained_profile = fetch_profile.profile
+          expect(obtained_profile).to eq(Profile.find_by(nickname: profile_name))
+        end
 
-      it 'updates the profile in the DB' do
-        call_fetch_profile
-        from_db = Profile.find_by(nickname: profile_name)
-        obtained = from_db.values_at(:followers_count, :followings_count, :public_gists_count, :public_repos_count)
-        expected = profile_data.values_at(:followers_count, :followings_count, :public_gists_count, :public_repos_count)
-
-        expect(obtained).to eq(expected)
-      end
-
-      it 'returns the right code' do
-        call_fetch_profile
-        obtained_code = fetch_profile.code
-        expect(obtained_code).to eq(200)
-      end
-
-      it 'returns the profile updated, in the body' do
-        call_fetch_profile
-        obtained_profile = fetch_profile.body
-        expect(obtained_profile).to eq(Profile.find_by(nickname: profile_name))
-      end
-
-      it 'returns the right profile from DB' do
-        call_fetch_profile
-        expect(Profile.find_by(nickname: profile_name)[:url]).to eq(profile_url)
-      end
-    end
-
-    describe 'profile from Github: doesn\'t exist, profile from DB: exists' do
-      let(:location)  { create(:location) }
-      let(:profile) { create(:profile, nickname: profile_name, location: location) }
-
-      before do
-        profile_call_fetch_profile = instance_double(
-          Github::ProfileConsumer,
-          call: {},
-          code: 404,
-          body: nil
-        )
-        allow(Github::ProfileConsumer).to receive(:new).and_return(profile_call_fetch_profile)
-
-        profile
-      end
-
-      it 'destroys the profile' do
-        call_fetch_profile
-        expect(Profile.find_by(nickname: profile_name)).to be_nil
-      end
-
-      it 'returns nil' do
-        expect(call_fetch_profile).to be_nil
-      end
-
-      it 'returns nil body' do
-        expect(fetch_profile.body).to be_nil
-      end
-
-      it 'returns the right code' do
-        call_fetch_profile
-        obtained_code = fetch_profile.code
-        expect(obtained_code).to eq(404)
+        it 'returns the right profile from DB' do
+          fetch_profile.call
+          expect(Profile.find_by(nickname: profile_name)[:url]).to eq(profile_url)
+        end
       end
     end
   end

--- a/spec/services/sync/fetch_profile_spec.rb
+++ b/spec/services/sync/fetch_profile_spec.rb
@@ -133,5 +133,41 @@ RSpec.describe Sync::FetchProfile do
         expect(Profile.find_by(nickname: profile_name)[:url]).to eq(profile_url)
       end
     end
+
+    describe 'profile from Github: doesn\'t exist, profile from DB: exists' do
+      let(:location)  { create(:location) }
+      let(:profile) { create(:profile, nickname: profile_name, location: location) }
+
+      before do
+        profile_call_fetch_profile = instance_double(
+          Github::ProfileConsumer,
+          call: {},
+          code: 404,
+          body: nil
+        )
+        allow(Github::ProfileConsumer).to receive(:new).and_return(profile_call_fetch_profile)
+
+        profile
+      end
+
+      it 'destroys the profile' do
+        call_fetch_profile
+        expect(Profile.find_by(nickname: profile_name)).to be_nil
+      end
+
+      it 'returns nil' do
+        expect(call_fetch_profile).to be_nil
+      end
+
+      it 'returns nil body' do
+        expect(fetch_profile.body).to be_nil
+      end
+
+      it 'returns the right code' do
+        call_fetch_profile
+        obtained_code = fetch_profile.code
+        expect(obtained_code).to eq(404)
+      end
+    end
   end
 end

--- a/spec/services/sync/sync_profile_spec.rb
+++ b/spec/services/sync/sync_profile_spec.rb
@@ -37,25 +37,39 @@ RSpec.describe Sync::SyncProfile do
     end
   end
 
-  describe '#update_profile' do
+  describe 'when a profile exists on DB' do
     let(:existing_profile) { create(:profile, nickname: profile_name, git_date: '2019-08-03T00:16:27Z', url: 'a') }
-    let(:response) { initialized_sync.update_profile(existing_profile) }
 
-    before do
-      existing_profile
+    describe '#update_profile' do
+      let(:response) { initialized_sync.update_profile(existing_profile) }
+
+      it 'returns a Profile' do
+        expect(response).to be_a(Profile)
+      end
+
+      it 'updates the profile' do
+        response
+        profile = Profile.find_by(nickname: profile_name)
+        updated_date = Date.parse profile_data[:git_date]
+        check_points = profile.url == profile_url && profile.git_date == updated_date
+
+        expect(check_points).to eq(true)
+      end
     end
 
-    it 'returns a Profile' do
-      expect(response).to be_a(Profile)
-    end
+    describe '#delete_profile' do
+      let(:response) { initialized_sync.delete_profile(existing_profile) }
 
-    it 'updates the profile' do
-      response
-      profile = Profile.find_by(nickname: profile_name)
-      updated_date = Date.parse profile_data[:git_date]
-      check_points = profile.url == profile_url && profile.git_date == updated_date
+      it 'returns nil' do
+        expect(response).to be_nil
+      end
 
-      expect(check_points).to eq(true)
+      it 'deletes the profile on DB' do
+        response
+        profile = Profile.find_by(nickname: profile_name)
+
+        expect(profile.nil?).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR allows FetchProfile to destroy an existing profile in DB, but not existing in github